### PR TITLE
merge(feat/args) Add configuration parsing and exit on error

### DIFF
--- a/Wolfram.cabal
+++ b/Wolfram.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Lib
+      Conf
   other-modules:
       Paths_Wolfram
   autogen-modules:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,15 @@
 module Main (main) where
 
-import Lib
+import System.Exit (exitWith, exitSuccess, ExitCode(ExitFailure))
+import System.IO (hPutStrLn, stderr)
+import Conf (getConf, Conf(Conf, rule))
+import Lib (wolfram)
 
 main :: IO ()
-main = someFunc
+main = do
+    conf <- getConf
+    case conf of
+        Nothing -> hPutStrLn stderr "Invalid arguments" >> exitWith (ExitFailure 84)
+        Just (Conf {rule=Nothing}) -> hPutStrLn stderr "No rule specified, use `--rule <rule number>'" >> exitWith (ExitFailure 84)
+        Just config -> wolfram config
+    exitSuccess

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,9 @@ ghc-options:
 
 library:
   source-dirs: src
+  exposed-modules:
+    - Lib
+    - Conf
 
 executables:
   wolfram:

--- a/src/Conf.hs
+++ b/src/Conf.hs
@@ -1,0 +1,41 @@
+module Conf (Conf(Conf, rule, start, width, iterations, offset), getConf) where
+
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
+
+data Conf = Conf {
+    rule :: Maybe Int,
+    start :: Int,
+    iterations :: Maybe Int,
+    width :: Int,
+    offset :: Int
+} deriving Show
+
+maybePositive :: Int -> Maybe Int
+maybePositive x | x > 0 = Just x
+                | otherwise = Nothing
+
+maybeByte :: Int -> Maybe Int
+maybeByte x | 0 < x && x < 255 = Just x
+            | otherwise = Nothing
+
+readConf :: Conf -> [String] -> Maybe Conf
+readConf c [] = Just c
+readConf c ("--rule":r:xs) = (\x -> readConf c {rule = Just x} xs) =<< maybeByte =<< readMaybe r
+readConf c ("--start":s:xs) = (\x -> readConf c {start = x} xs) =<< maybePositive =<< readMaybe s
+readConf c ("--lines":i:xs) = (\x -> readConf c {iterations = Just x} xs) =<< maybePositive =<< readMaybe i
+readConf c ("--window":w:xs) = (\x -> readConf c {width = x} xs) =<< maybePositive =<< readMaybe w
+readConf c ("--move":m:xs) = (\x -> readConf c {offset = x} xs) =<< readMaybe m
+readConf _ _ = Nothing
+
+defaultConf :: Conf
+defaultConf = Conf {
+    rule = Nothing,
+    start = 0,
+    iterations = Nothing,
+    width = 80,
+    offset = 0
+}
+
+getConf :: IO (Maybe Conf)
+getConf = readConf defaultConf <$> getArgs

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,6 @@
-module Lib
-    ( someFunc
-    ) where
+module Lib (wolfram) where
 
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"
+import Conf (Conf)
+
+wolfram :: Conf -> IO ()
+wolfram = print


### PR DESCRIPTION
# Contents
- Add `Conf` module and type conatining all the program's configuration, parsed from the command line
- Main now exit with an error on invalid arguments